### PR TITLE
Bump CI Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v5"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
       - name: "Linting: black"
         run: "poetry run invoke black"
   bandit:
@@ -35,7 +35,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v5"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
       - name: "Linting: bandit"
         run: "poetry run invoke bandit"
   ruff:
@@ -46,7 +46,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v5"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
       - name: "Linting: ruff"
         run: "poetry run invoke ruff"
   check-docs-build:
@@ -57,7 +57,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v5"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
       - name: "Check Docs Build"
         run: "poetry run invoke build-and-check-docs"
   flake8:
@@ -68,7 +68,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v5"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
       - name: "Linting: flake8"
         run: "poetry run invoke flake8"
   poetry:
@@ -79,7 +79,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v5"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
       - name: "Checking: poetry lock file"
         run: "poetry run invoke lock --check"
   yamllint:
@@ -90,7 +90,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v5"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
       - name: "Linting: yamllint"
         run: "poetry run invoke yamllint"
   check-in-docker:
@@ -114,7 +114,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v5"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
       - name: "Set up Docker Buildx"
         id: "buildx"
         uses: "docker/setup-buildx-action@v3"
@@ -164,7 +164,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v5"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
       - name: "Set up Docker Buildx"
         id: "buildx"
         uses: "docker/setup-buildx-action@v3"
@@ -200,7 +200,7 @@ jobs:
         with:
           fetch-depth: "0"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v5"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
       - name: "Check for changelog entry"
         run: |
           git fetch --no-tags origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
@@ -217,7 +217,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Set up Python"
-        uses: "actions/setup-python@v4"
+        uses: "actions/setup-python@v5"
         with:
           python-version: "3.11"
       - name: "Install Python Packages"
@@ -252,7 +252,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Set up Python"
-        uses: "actions/setup-python@v4"
+        uses: "actions/setup-python@v5"
         with:
           python-version: "3.11"
       - name: "Install Python Packages"

--- a/changes/7.housekeeping
+++ b/changes/7.housekeeping
@@ -1,0 +1,2 @@
+Bumped `networktocode/gh-action-setup-poetry-environment` from `v5` to `v6`.
+Bumped `actions/setup-python` from `v4` to `v5`.


### PR DESCRIPTION
# Closes Nan

To resolve the following messages in CI:

```plaintext
! Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

## What's Changed

- Updated CI actions to latest versions.
