### PR TITLE
Ruff integration 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,8 @@ jobs:
   check-in-docker:
     needs:
       - "bandit"
-      - "ruff"
+      - "ruff-format"
+      - "ruff-lint"
       - "poetry"
       - "yamllint"
     runs-on: "ubuntu-22.04"

--- a/changes/16.housekeeping
+++ b/changes/16.housekeeping
@@ -1,0 +1,1 @@
+More additions on ruff integration.

--- a/nautobot_dev_example/tests/test_basic.py
+++ b/nautobot_dev_example/tests/test_basic.py
@@ -22,4 +22,4 @@ class TestDocsPackaging(unittest.TestCase):
                 package_name, version = pkg.split("==")
             else:
                 version = "*"
-            self.assertEqual(poetry_details[pkg], version)
+            self.assertEqual(poetry_details[package_name], version)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,9 +124,6 @@ convention = "google"
 [tool.ruff.lint.per-file-ignores]
 "nautobot_dev_example/migrations/*" = [
     "D",
-    "F",
-    "E",
-    "W"
 ]
 "nautobot_dev_example/tests/*" = [
     "D",


### PR DESCRIPTION
- fixes test_basic package_name variable usage
- re-enable ruff against migration files

Note that I have not changed the invoke setup as there wasn't a clear consensus on doing that. If you want a one-stop-shop for formatting, use `inv a[utoformat]`.
