### PR TITLE
fix invoke ruff always exiting with zero status

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -156,7 +156,7 @@ def run_command(context, command, **kwargs):
                 **kwargs.get("env", {}),
                 **kwargs.pop("command_env"),
             }
-        context.run(command, **kwargs)
+        return context.run(command, **kwargs)
     else:
         # Check if nautobot is running, no need to start another nautobot container to run a command
         docker_compose_status = "ps --services --filter status=running"
@@ -175,7 +175,7 @@ def run_command(context, command, **kwargs):
 
         pty = kwargs.pop("pty", True)
 
-        docker_compose(context, compose_command, pty=pty, **kwargs)
+        return docker_compose(context, compose_command, pty=pty, **kwargs)
 
 
 # ------------------------------------------------------------------------------
@@ -724,12 +724,15 @@ def ruff(context, action=None, target=None, fix=False, output_format="concise"):
     if not target:
         target = ["."]
 
+    exit_code = 0
+
     if "format" in action:
         command = "ruff format "
         if not fix:
             command += "--check "
         command += " ".join(target)
-        run_command(context, command, warn=True)
+        if not run_command(context, command, warn=True):
+            exit_code = 1
 
     if "lint" in action:
         command = "ruff check "
@@ -737,7 +740,10 @@ def ruff(context, action=None, target=None, fix=False, output_format="concise"):
             command += "--fix "
         command += f"--output-format {output_format} "
         command += " ".join(target)
-        run_command(context, command, warn=True)
+        if not run_command(context, command, warn=True):
+            exit_code = 1
+
+    raise Exit(code=exit_code)
 
 
 @task


### PR DESCRIPTION
https://github.com/nautobot/cookiecutter-nautobot-app/issues/160

```sh
(nautobot-dev-example-py3.12) $ INVOKE_NAUTOBOT_DEV_EXAMPLE_LOCAL=true invoke ruff; echo $?
Would reformat: nautobot_dev_example/forms.py
1 file would be reformatted, 25 files already formatted
nautobot_dev_example/forms.py:20:14: F541 [*] f-string without any placeholders
Found 1 error.
[*] 1 fixable with the `--fix` option.
1


(nautobot-dev-example-py3.12) $ INVOKE_NAUTOBOT_DEV_EXAMPLE_LOCAL=true invoke ruff; echo $?
26 files already formatted
All checks passed!
0
```