### PR TITLE
add fallback to git branch for `invoke lock` and Dockerfile `poetry add`

### DIFF
--- a/changes/44.fixed
+++ b/changes/44.fixed
@@ -1,0 +1,1 @@
+Fixed build failing when `NAUTOBOT_VER` doesn't exist in PyPi, for example when using a branch name.

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -54,14 +54,16 @@ WORKDIR /source
 COPY . /source
 
 # Build args must be declared in each stage
+ARG NAUTOBOT_VER
 ARG PYTHON_VER
 
-# Constrain the Nautobot version to NAUTOBOT_VER
+# Constrain the Nautobot version to NAUTOBOT_VER, fall back to installing from git branch if not available on PyPi
 # In CI, this should be done outside of the Dockerfile to prevent cross-compile build failures
 ARG CI
 RUN if [ -z "${CI+x}" ]; then \
     INSTALLED_NAUTOBOT_VER=$(pip show nautobot | grep "^Version" | sed "s/Version: //"); \
-    poetry add --lock nautobot@${INSTALLED_NAUTOBOT_VER} --python ${PYTHON_VER}; fi
+    poetry add --lock nautobot@${INSTALLED_NAUTOBOT_VER} --python ${PYTHON_VER} || \
+    poetry add --lock git+https://github.com/nautobot/nautobot.git#${NAUTOBOT_VER} --python ${PYTHON_VER}; fi
 
 # Install the app
 RUN poetry install --extras all --with dev

--- a/nautobot_dev_example/forms.py
+++ b/nautobot_dev_example/forms.py
@@ -15,6 +15,7 @@ class DevExampleForm(NautobotModelForm):  # pylint: disable=too-many-ancestors
         model = models.DevExample
         fields = "__all__"
 
+
 class DevExampleBulkEditForm(TagsBulkEditFormMixin, NautobotBulkEditForm):  # pylint: disable=too-many-ancestors
     """DevExample bulk edit form."""
 

--- a/tasks.py
+++ b/tasks.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from time import sleep
 
 from invoke.collection import Collection
-from invoke.exceptions import Exit
+from invoke.exceptions import Exit, UnexpectedExit
 from invoke.tasks import task as invoke_task
 
 
@@ -249,9 +249,17 @@ def lock(context, check=False, constrain_nautobot_ver=False, constrain_python_ve
         command = f"poetry add --lock nautobot@{docker_nautobot_version}"
         if constrain_python_ver:
             command += f" --python {context.nautobot_dev_example.python_ver}"
+        try:
+            run_command(context, command, hide=True)
+        except UnexpectedExit:
+            print("Unable to add Nautobot dependency with version constraint, falling back to git branch.")
+            command = f"poetry add --lock git+https://github.com/nautobot/nautobot.git#{context.nautobot_dev_example.nautobot_ver}"
+            if constrain_python_ver:
+                command += f" --python {context.nautobot_dev_example.python_ver}"
+            run_command(context, command)
     else:
         command = f"poetry {'check' if check else 'lock --no-update'}"
-    run_command(context, command)
+        run_command(context, command)
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes the issue that prevents you from using a branch name in your `NAUTOBOT_VER`. See https://github.com/nautobot/cookiecutter-nautobot-app/issues/167

Test upstream testing workflow with these changes: https://github.com/gsnider2195/nautobot-app-dev-example/actions/runs/10892662923