### PR TITLE
fix output on invoke lock command

### DIFF
--- a/changes/47.fixed
+++ b/changes/47.fixed
@@ -1,0 +1,1 @@
+Fixed output on `invoke lock` command.

--- a/tasks.py
+++ b/tasks.py
@@ -14,6 +14,7 @@ limitations under the License.
 
 import os
 import re
+import sys
 from pathlib import Path
 from time import sleep
 
@@ -250,7 +251,9 @@ def lock(context, check=False, constrain_nautobot_ver=False, constrain_python_ve
         if constrain_python_ver:
             command += f" --python {context.nautobot_dev_example.python_ver}"
         try:
-            run_command(context, command, hide=True)
+            output = run_command(context, command, hide=True)
+            print(output.stdout, end="")
+            print(output.stderr, file=sys.stderr, end="")
         except UnexpectedExit:
             print("Unable to add Nautobot dependency with version constraint, falling back to git branch.")
             command = f"poetry add --lock git+https://github.com/nautobot/nautobot.git#{context.nautobot_dev_example.nautobot_ver}"


### PR DESCRIPTION
I mistakenly hid the output on `invoke lock --constrain-nautobot-ver` when using a valid `NAUTOBOT_VER`. This fixes that:


```
gary@gary-work$ INVOKE_NAUTOBOT_DEV_EXAMPLE_NAUTOBOT_VER=develop INVOKE_NAUTOBOT_DE
V_EXAMPLE_LOCAL=true inv lock --constrain-nautobot-ver --constrain-python-ver
Unable to add Nautobot dependency with version constraint, falling back to git branch.

Updating dependencies
Resolving dependencies...
```
```
gary@gary-work$ INVOKE_NAUTOBOT_DEV_EXAMPLE_NAUTOBOT_VER=2.3.2 INVOKE_NAUTOBOT_DEV_
EXAMPLE_LOCAL=true inv lock --constrain-nautobot-ver --constrain-python-ver

Updating dependencies
Resolving dependencies...

Writing lock file
```