### PR TITLE
add pylint_django migrations check

### DIFF
--- a/changes/50.added
+++ b/changes/50.added
@@ -1,0 +1,1 @@
+Added pylint django migrations checker to the `invoke pylint` command.

--- a/tasks.py
+++ b/tasks.py
@@ -711,16 +711,18 @@ def pylint(context):
     """Run pylint code analysis."""
     exit_code = 0
 
-    command = 'pylint --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml nautobot_dev_example'
+    base_pylint_command = 'pylint --verbose --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml'
+    command = f"{base_pylint_command} nautobot_dev_example"
     if not run_command(context, command, warn=True):
         exit_code = 1
 
     # run the pylint_django migrations checkers on the migrations directory
-    migrations_pylint = (
-        'pylint --verbose --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml '
-        "--load-plugins=pylint_django.checkers.migrations --disable=all --enable=new-db-field-with-default,missing-backwards-migration-callable nautobot_dev_example.migrations"
+    migrations_pylint_command = (
+        f"{base_pylint_command} --load-plugins=pylint_django.checkers.migrations"
+        " --disable=all --enable=new-db-field-with-default,missing-backwards-migration-callable"
+        " nautobot_dev_example.migrations"
     )
-    if not run_command(context, migrations_pylint, warn=True):
+    if not run_command(context, migrations_pylint_command, warn=True):
         exit_code = 1
 
     raise Exit(code=exit_code)


### PR DESCRIPTION
## Test code with failure

### `nautobot_dev_example/migrations/0002_runpython.py`

```py
# Generated by Django 3.2.21 on 2024-02-16 08:32

from django.db import migrations


def runpython_noop(apps, schema_editor):
    pass


class Migration(migrations.Migration):
    dependencies = [
        ("nautobot_dev_example", "0001_initial"),
    ]

    operations = [migrations.RunPython(code=runpython_noop)]
```

### Output

```sh
$ inv pylint
Running docker compose command "ps --services --filter status=running"
>>>> Executing external compose provider "/usr/libexec/docker/cli-plugins/docker-compose". Please refer to the documentation for details. <<<<

Running docker compose command "run --rm --entrypoint='pylint --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml nautobot_dev_example' nautobot"
>>>> Executing external compose provider "/usr/libexec/docker/cli-plugins/docker-compose". Please refer to the documentation for details. <<<<

[+] Creating 2/0
 ✔ Container nautobot-dev-example-db-1     Running                                                                                                      0.0s 
 ✔ Container nautobot-dev-example-redis-1  Running                                                                                                      0.0s 
18:11:05.133 INFO    nautobot             __init__.py                              setup() : Nautobot initialized!

------------------------------------
Your code has been rated at 10.00/10

Running docker compose command "ps --services --filter status=running"
>>>> Executing external compose provider "/usr/libexec/docker/cli-plugins/docker-compose". Please refer to the documentation for details. <<<<

Running docker compose command "run --rm --entrypoint='pylint --verbose --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml --load-plugins=pylint_django.checkers.migrations --disable=all --enable=new-db-field-with-default,missing-backwards-migration-callable nautobot_dev_example.migrations' nautobot"
>>>> Executing external compose provider "/usr/libexec/docker/cli-plugins/docker-compose". Please refer to the documentation for details. <<<<

[+] Creating 2/0
 ✔ Container nautobot-dev-example-redis-1  Running                                                                                                      0.0s 
 ✔ Container nautobot-dev-example-db-1     Running                                                                                                      0.0s 
18:11:17.139 INFO    nautobot             __init__.py                              setup() : Nautobot initialized!
Using config file pyproject.toml
************* Module nautobot_dev_example.migrations.0002_runpython
nautobot_dev_example/migrations/0002_runpython.py:15:18: W5197: Always include backwards migration callable (missing-backwards-migration-callable)

-----------------------------------
Your code has been rated at 9.33/10

Error: executing /usr/libexec/docker/cli-plugins/docker-compose --project-name nautobot-dev-example --project-directory /home/gary/github/nautobot/nautobot-app-dev-example/development -f /home/gary/github/nautobot/nautobot-app-dev-example/development/docker-compose.base.yml -f /home/gary/github/nautobot/nautobot-app-dev-example/development/docker-compose.redis.yml -f /home/gary/github/nautobot/nautobot-app-dev-example/development/docker-compose.postgres.yml -f /home/gary/github/nautobot/nautobot-app-dev-example/development/docker-compose.dev.yml run --rm --entrypoint=pylint --verbose --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml --load-plugins=pylint_django.checkers.migrations --disable=all --enable=new-db-field-with-default,missing-backwards-migration-callable nautobot_dev_example.migrations nautobot: exit status 4
$ echo $?
1
$ 
```

## Test code with success

### `nautobot_dev_example/migrations/0002_runpython.py`

```py
# Generated by Django 3.2.21 on 2024-02-16 08:32

from django.db import migrations


def runpython_noop(apps, schema_editor):
    pass


class Migration(migrations.Migration):
    dependencies = [
        ("nautobot_dev_example", "0001_initial"),
    ]

    operations = [migrations.RunPython(code=runpython_noop, reverse_code=migrations.RunPython.noop)]
```

### Output

```sh
$ inv pylint
Running docker compose command "ps --services --filter status=running"
>>>> Executing external compose provider "/usr/libexec/docker/cli-plugins/docker-compose". Please refer to the documentation for details. <<<<

Running docker compose command "run --rm --entrypoint='pylint --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml nautobot_dev_example' nautobot"
>>>> Executing external compose provider "/usr/libexec/docker/cli-plugins/docker-compose". Please refer to the documentation for details. <<<<

[+] Creating 2/0
 ✔ Container nautobot-dev-example-db-1     Running                                                                                                      0.0s 
 ✔ Container nautobot-dev-example-redis-1  Running                                                                                                      0.0s 
18:14:40.335 INFO    nautobot             __init__.py                              setup() : Nautobot initialized!

------------------------------------
Your code has been rated at 10.00/10

Running docker compose command "ps --services --filter status=running"
>>>> Executing external compose provider "/usr/libexec/docker/cli-plugins/docker-compose". Please refer to the documentation for details. <<<<

Running docker compose command "run --rm --entrypoint='pylint --verbose --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml --load-plugins=pylint_django.checkers.migrations --disable=all --enable=new-db-field-with-default,missing-backwards-migration-callable nautobot_dev_example.migrations' nautobot"
>>>> Executing external compose provider "/usr/libexec/docker/cli-plugins/docker-compose". Please refer to the documentation for details. <<<<

[+] Creating 2/0
 ✔ Container nautobot-dev-example-db-1     Running                                                                                                      0.0s 
 ✔ Container nautobot-dev-example-redis-1  Running                                                                                                      0.0s 
18:14:52.505 INFO    nautobot             __init__.py                              setup() : Nautobot initialized!
Using config file pyproject.toml

------------------------------------
Your code has been rated at 10.00/10

$ echo $?
0
$ 
```