### PR TITLE
release v3.0.0

### DIFF
--- a/docs/admin/release_notes/version_3.0.md
+++ b/docs/admin/release_notes/version_3.0.md
@@ -1,0 +1,16 @@
+# v3.0 Release Notes
+
+This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release Overview
+
+- Added support for Nautobot 3.0.
+- Added support for Python 3.13.
+
+<!-- towncrier release notes start -->
+## [v3.0.0 (2025-11-06)](https://github.com/nautobot/nautobot-app-dev-example/releases/tag/v3.0.0)
+
+### Added
+
+- Added support for Nautobot 3.0.
+- Added support for Python 3.13.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
       - Compatibility Matrix: "admin/compatibility_matrix.md"
       - Release Notes:
           - "admin/release_notes/index.md"
+          - v3.0: "admin/release_notes/version_3.0.md"
           - v2.2: "admin/release_notes/version_2.2.md"
           - v2.1: "admin/release_notes/version_2.1.md"
           - v2.0: "admin/release_notes/version_2.0.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-dev-example"
-version = "2.3.0a0"
+version = "3.0.0"
 description = "Nautobot App to demonstrate how to create a Nautobot App."
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"
@@ -29,8 +29,7 @@ include = [
 [tool.poetry.dependencies]
 python = ">=3.10,<3.14"
 # Used for local development
-nautobot = {git = "https://github.com/nautobot/nautobot.git", rev = "next"}
-# nautobot = "^3.0.0"  # TODO: Uncomment after v3.0.0 is released
+nautobot = ">=3.0.0,<4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "*"


### PR DESCRIPTION
This is to test releasing a 3.0.0 compatible version before Nautobot v3.0 is released. This PR will likely fail CI due to the lockfile not being valid.