### PR TITLE
Regenerate poetry.lock in locally run CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,28 @@ env:
   APP_NAME: "nautobot-dev-example"
 
 jobs:
+  generate-lockfile:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Regenerate poetry.lock"
+        run: "poetry lock --regenerate"
+      - name: "Upload poetry.lock"
+        uses: "actions/upload-artifact@v4"
+        with:
+          name: "poetry-lock"
+          path: "poetry.lock"
   ruff-format:
+    needs: "generate-lockfile"
     runs-on: "ubuntu-latest"
     env:
       INVOKE_NAUTOBOT_DEV_EXAMPLE_LOCAL: "True"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
+      - name: "Download poetry.lock"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "poetry-lock"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
@@ -28,12 +43,17 @@ jobs:
       - name: "Linting: ruff format"
         run: "poetry run invoke ruff --action format"
   ruff-lint:
+    needs: "generate-lockfile"
     runs-on: "ubuntu-latest"
     env:
       INVOKE_NAUTOBOT_DEV_EXAMPLE_LOCAL: "True"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
+      - name: "Download poetry.lock"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "poetry-lock"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
@@ -41,12 +61,17 @@ jobs:
       - name: "Linting: ruff"
         run: "poetry run invoke ruff --action lint"
   check-docs-build:
+    needs: "generate-lockfile"
     runs-on: "ubuntu-latest"
     env:
       INVOKE_NAUTOBOT_DEV_EXAMPLE_LOCAL: "True"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
+      - name: "Download poetry.lock"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "poetry-lock"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
@@ -68,12 +93,17 @@ jobs:
       - name: "Checking: poetry lock file"
         run: "poetry run invoke lock --check"
   yamllint:
+    needs: "generate-lockfile"
     runs-on: "ubuntu-latest"
     env:
       INVOKE_NAUTOBOT_DEV_EXAMPLE_LOCAL: "True"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
+      - name: "Download poetry.lock"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "poetry-lock"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
@@ -81,12 +111,17 @@ jobs:
       - name: "Linting: yamllint"
         run: "poetry run invoke yamllint"
   markdownlint:
+    needs: "generate-lockfile"
     runs-on: "ubuntu-latest"
     env:
       INVOKE_NAUTOBOT_DEV_EXAMPLE_LOCAL: "True"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
+      - name: "Download poetry.lock"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "poetry-lock"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
@@ -273,6 +308,7 @@ jobs:
           path: "python-coverage-comment-action.txt"
 
   changelog:
+    needs: "generate-lockfile"
     if: >
       contains(fromJson('["develop","ltm-1.6"]'), github.base_ref) &&
       (github.head_ref != 'main') && (!startsWith(github.head_ref, 'release'))
@@ -282,6 +318,10 @@ jobs:
         uses: "actions/checkout@v4"
         with:
           fetch-depth: "0"
+      - name: "Download poetry.lock"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "poetry-lock"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
-      - name: "Download poetry.lock"
+      - name: "Download poetry.lock artifact"
         uses: "actions/download-artifact@v4"
         with:
           name: "poetry-lock"
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
-      - name: "Download poetry.lock"
+      - name: "Download poetry.lock artifact"
         uses: "actions/download-artifact@v4"
         with:
           name: "poetry-lock"
@@ -75,7 +75,7 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
-      - name: "Download poetry.lock"
+      - name: "Download poetry.lock artifact"
         uses: "actions/download-artifact@v4"
         with:
           name: "poetry-lock"
@@ -107,7 +107,7 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
-      - name: "Download poetry.lock"
+      - name: "Download poetry.lock artifact"
         uses: "actions/download-artifact@v4"
         with:
           name: "poetry-lock"
@@ -125,7 +125,7 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
-      - name: "Download poetry.lock"
+      - name: "Download poetry.lock artifact"
         uses: "actions/download-artifact@v4"
         with:
           name: "poetry-lock"
@@ -325,7 +325,7 @@ jobs:
         uses: "actions/checkout@v4"
         with:
           fetch-depth: "0"
-      - name: "Download poetry.lock"
+      - name: "Download poetry.lock artifact"
         uses: "actions/download-artifact@v4"
         with:
           name: "poetry-lock"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
   generate-lockfile:
     runs-on: "ubuntu-latest"
     steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v4"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
   generate-lockfile:
     runs-on: "ubuntu-latest"
     steps:
+      - name: "Setup environment"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        with:
+          poetry-version: "2.1.3"
+          poetry-install-options: "--only-root"
       - name: "Regenerate poetry.lock"
         run: "poetry lock --regenerate"
       - name: "Upload poetry.lock"

--- a/changes/128.housekeeping
+++ b/changes/128.housekeeping
@@ -1,0 +1,1 @@
+Updated CI workflow to always regenerate poetry lockfile.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot Dev Example App! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: NAPPS-660

## What's Changed

Updated the CI workflow to always regenerate the lockfile when running the local CI steps (steps where `INVOKE_NAUTOBOT_DEV_EXAMPLE_LOCAL=True`). This already happens implicitly in the other steps where we run `invoke lock --constrain-nautobot-ver`

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
