### PR TITLE
Testing gh-action-setup-poetry-environment change using pipx instead of curl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on: # yamllint disable-line rule:truthy rule:comments
       - "main"
       - "develop"
   pull_request: ~
+  workflow_dispatch:
 
 env:
   APP_NAME: "nautobot-dev-example"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: ruff format"
@@ -35,7 +35,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: ruff"
@@ -48,7 +48,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
         with:
           poetry-version: "2.1.3"
           poetry-install-options: "--only dev,docs"
@@ -62,7 +62,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
         with:
           poetry-version: "2.1.3"
       - name: "Checking: poetry lock file"
@@ -75,7 +75,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: yamllint"
@@ -88,7 +88,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: markdownlint"
@@ -113,7 +113,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
         with:
           poetry-version: "2.1.3"
       - name: "Constrain Nautobot version and regenerate lock file"
@@ -168,7 +168,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
         with:
           poetry-version: "2.1.3"
       - name: "Constrain Nautobot version and regenerate lock file"
@@ -219,7 +219,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
         with:
           poetry-version: "2.1.3"
       - name: "Constrain Nautobot version and regenerate lock file"
@@ -283,7 +283,7 @@ jobs:
         with:
           fetch-depth: "0"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
         with:
           poetry-version: "2.1.3"
       - name: "Check for changelog entry"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on: # yamllint disable-line rule:truthy rule:comments
       - "main"
       - "develop"
   pull_request: ~
-  workflow_dispatch:
 
 env:
   APP_NAME: "nautobot-dev-example"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
+        uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: ruff format"
@@ -35,7 +35,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
+        uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: ruff"
@@ -48,7 +48,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
+        uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
           poetry-version: "2.1.3"
           poetry-install-options: "--only dev,docs"
@@ -62,7 +62,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
+        uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
           poetry-version: "2.1.3"
       - name: "Checking: poetry lock file"
@@ -75,7 +75,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
+        uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: yamllint"
@@ -88,7 +88,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
+        uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: markdownlint"
@@ -113,7 +113,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
+        uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
           poetry-version: "2.1.3"
       - name: "Constrain Nautobot version and regenerate lock file"
@@ -168,7 +168,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
+        uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
           poetry-version: "2.1.3"
       - name: "Constrain Nautobot version and regenerate lock file"
@@ -219,7 +219,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
+        uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
           poetry-version: "2.1.3"
       - name: "Constrain Nautobot version and regenerate lock file"
@@ -283,7 +283,7 @@ jobs:
         with:
           fetch-depth: "0"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
+        uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
           poetry-version: "2.1.3"
       - name: "Check for changelog entry"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
+        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: ruff format"
@@ -35,7 +35,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
+        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: ruff"
@@ -48,7 +48,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
+        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
         with:
           poetry-version: "2.1.3"
           poetry-install-options: "--only dev,docs"
@@ -62,7 +62,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
+        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
         with:
           poetry-version: "2.1.3"
       - name: "Checking: poetry lock file"
@@ -75,7 +75,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
+        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: yamllint"
@@ -88,7 +88,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
+        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: markdownlint"
@@ -113,7 +113,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
+        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
         with:
           poetry-version: "2.1.3"
       - name: "Constrain Nautobot version and regenerate lock file"
@@ -168,7 +168,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
+        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
         with:
           poetry-version: "2.1.3"
       - name: "Constrain Nautobot version and regenerate lock file"
@@ -219,7 +219,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
+        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
         with:
           poetry-version: "2.1.3"
       - name: "Constrain Nautobot version and regenerate lock file"
@@ -283,7 +283,7 @@ jobs:
         with:
           fetch-depth: "0"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
+        uses: "networktocode/gh-action-setup-poetry-environment@cdbea018cea3eacea3eb79afa3db67185e9caa4f"
         with:
           poetry-version: "2.1.3"
       - name: "Check for changelog entry"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
+        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: ruff format"
@@ -35,7 +35,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
+        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: ruff"
@@ -48,7 +48,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
+        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
         with:
           poetry-version: "2.1.3"
           poetry-install-options: "--only dev,docs"
@@ -62,7 +62,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
+        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
         with:
           poetry-version: "2.1.3"
       - name: "Checking: poetry lock file"
@@ -75,7 +75,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
+        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: yamllint"
@@ -88,7 +88,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
+        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: markdownlint"
@@ -113,7 +113,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
+        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
         with:
           poetry-version: "2.1.3"
       - name: "Constrain Nautobot version and regenerate lock file"
@@ -168,7 +168,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
+        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
         with:
           poetry-version: "2.1.3"
       - name: "Constrain Nautobot version and regenerate lock file"
@@ -219,7 +219,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
+        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
         with:
           poetry-version: "2.1.3"
       - name: "Constrain Nautobot version and regenerate lock file"
@@ -283,7 +283,7 @@ jobs:
         with:
           fetch-depth: "0"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e"
+        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
         with:
           poetry-version: "2.1.3"
       - name: "Check for changelog entry"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: ruff format"
@@ -35,7 +35,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: ruff"
@@ -48,7 +48,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
         with:
           poetry-version: "2.1.3"
           poetry-install-options: "--only dev,docs"
@@ -62,7 +62,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
         with:
           poetry-version: "2.1.3"
       - name: "Checking: poetry lock file"
@@ -75,7 +75,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: yamllint"
@@ -88,7 +88,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
         with:
           poetry-version: "2.1.3"
       - name: "Linting: markdownlint"
@@ -113,7 +113,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
         with:
           poetry-version: "2.1.3"
       - name: "Constrain Nautobot version and regenerate lock file"
@@ -168,7 +168,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
         with:
           poetry-version: "2.1.3"
       - name: "Constrain Nautobot version and regenerate lock file"
@@ -219,7 +219,7 @@ jobs:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
         with:
           poetry-version: "2.1.3"
       - name: "Constrain Nautobot version and regenerate lock file"
@@ -283,7 +283,7 @@ jobs:
         with:
           fetch-depth: "0"
       - name: "Setup environment"
-        uses: "networktocode/gh-action-setup-poetry-environment@ab8b2534366a18c7c627f5a4b68bff480f3fcd65"
+        uses: "networktocode/gh-action-setup-poetry-environment@ccf825e15265c7312e2c83ff2c8dcf9ab86ff8c0"
         with:
           poetry-version: "2.1.3"
       - name: "Check for changelog entry"

--- a/changes/130.changed
+++ b/changes/130.changed
@@ -1,1 +1,1 @@
-Updated the Poetry install workflow to use version 7.
+Updated the Poetry install workflow to use `gh-action-setup-poetry-environment` version 7.

--- a/changes/130.changed
+++ b/changes/130.changed
@@ -1,0 +1,1 @@
+Updated the Poetry install workflow to use version 7.


### PR DESCRIPTION
# Closes: #NAPPS-662

## What's Changed
Updated the Poetry install workflow to use version 7. [gh-action-setup-poetry-environment](https://github.com/networktocode/gh-action-setup-poetry-environment) now installs poetry with pipx.