### PR TITLE
Update GH_TOKEN when creating pull request

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -150,7 +150,9 @@ jobs:
 
       - name: "Create Pull Request"
         env:
-          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          # To allow checks to run on PR, use Personal Access Token (GH_NAUTOBOT_BOT_TOKEN)
+          # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows
+          GH_TOKEN: "${{ secrets.GH_NAUTOBOT_BOT_TOKEN }}"
         run: |
           gh pr create \
             --title "Release v${{ env.NEW_VERSION }}" \

--- a/changes/159.housekeeping
+++ b/changes/159.housekeeping
@@ -1,0 +1,1 @@
+Housekeeping update Prepare-Release workflow to use a token when creating a PR so that GitHub Actions run.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot Dev Example App! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# NAPPS-1062

## What's Changed

This changes the behavior when the prepare release GHA runs, so that it uses a PAT instead of the default github-actions bot.  This allows checks to run.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
