### PR TITLE
Fix automated releases - prerelease version bump inconsistency

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -65,6 +65,8 @@ jobs:
 
       - name: "Determine New Version"
         id: "versioning"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           # Bump the poetry version based on the user input
           CURRENT_POETRY_VER=$(poetry version --short)

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -80,7 +80,7 @@ jobs:
 
           # If the bump rule is prerelease and a release doesn't already exist in github we don't bump the version
           # This is because we've already bumped to the prerelease version after the previous release
-          elif [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" && "$CURRENT_POETRY_VER" =~ \\(a|b|rc\\)\\d+\$ && -z "$GITHUB_RELEASE_EXISTS" ]]; then
+          elif [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" && "$CURRENT_POETRY_VER" =~ (a|b|rc)[0-9]+$ && -z "$GITHUB_RELEASE_EXISTS" ]]; then
             echo "Prerelease v$CURRENT_POETRY_VER does not exist in github, using this version"
 
           else

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -80,7 +80,7 @@ jobs:
 
           # If the bump rule is prerelease and a release doesn't already exist in github we don't bump the version
           # This is because we've already bumped to the prerelease version after the previous release
-          elif [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" && "$CURRENT_POETRY_VER" =~ \(a|b|rc\)\d+$ && -z "$GITHUB_RELEASE_EXISTS" ]]; then
+          elif [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" && "$CURRENT_POETRY_VER" =~ \\(a|b|rc\\)\\d+$ && -z "$GITHUB_RELEASE_EXISTS" ]]; then
             echo "Prerelease v$CURRENT_POETRY_VER does not exist in github, using this version"
 
           else

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -80,7 +80,7 @@ jobs:
 
           # If the bump rule is prerelease and a release doesn't already exist in github we don't bump the version
           # This is because we've already bumped to the prerelease version after the previous release
-          elif [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" && "$CURRENT_POETRY_VER" =~ \\(a|b|rc\\)\\d+$ && -z "$GITHUB_RELEASE_EXISTS" ]]; then
+          elif [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" && "$CURRENT_POETRY_VER" =~ \\(a|b|rc\\)\\d+\$ && -z "$GITHUB_RELEASE_EXISTS" ]]; then
             echo "Prerelease v$CURRENT_POETRY_VER does not exist in github, using this version"
 
           else

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -70,7 +70,9 @@ jobs:
         run: |
           # Bump the poetry version based on the user input
           CURRENT_POETRY_VER=$(poetry version --short)
+          set +e  # continue running if the next command fails
           GITHUB_RELEASE_EXISTS=$(gh release view v$CURRENT_POETRY_VER --json publishedAt --jq '.publishedAt')
+          set -e
 
           # Unconditionally bump the version if the current version is alpha0 or beta0
           if [[ $CURRENT_POETRY_VER == *a0 || $CURRENT_POETRY_VER == *b0 ]]; then

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -76,7 +76,6 @@ jobs:
 
           # Unconditionally bump the version if the current version is alpha0 or beta0
           if [[ $CURRENT_POETRY_VER == *a0 || $CURRENT_POETRY_VER == *b0 ]]; then
-            echo "Bumping poetry version"
             poetry version ${{ github.event.inputs.bump_rule }}
 
           # If the bump rule is prerelease and a release doesn't already exist in github we don't bump the version
@@ -85,7 +84,6 @@ jobs:
             echo "Prerelease v$CURRENT_POETRY_VER does not exist in github, using this version"
 
           else
-            echo "Bumping poetry version"
             poetry version ${{ github.event.inputs.bump_rule }}
           fi
 

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -80,7 +80,7 @@ jobs:
 
           # If the bump rule is prerelease and a release doesn't already exist in github we don't bump the version
           # This is because we've already bumped to the prerelease version after the previous release
-          elif [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" && "$CURRENT_POETRY_VER" =~ (a|b|rc)\\d+$ && -z "$GITHUB_RELEASE_EXISTS" ]]; then
+          elif [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" && "$CURRENT_POETRY_VER" =~ \\(a|b|rc\\)\\d+$ && -z "$GITHUB_RELEASE_EXISTS" ]]; then
             echo "Prerelease v$CURRENT_POETRY_VER does not exist in github, using this version"
 
           else

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -80,7 +80,7 @@ jobs:
 
           # If the bump rule is prerelease and a release doesn't already exist in github we don't bump the version
           # This is because we've already bumped to the prerelease version after the previous release
-          elif [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" && "$CURRENT_POETRY_VER" =~ (a|b|rc)\d+$ && -z "$GITHUB_RELEASE_EXISTS" ]]; then
+          elif [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" && "$CURRENT_POETRY_VER" =~ (a|b|rc)\\d+$ && -z "$GITHUB_RELEASE_EXISTS" ]]; then
             echo "Prerelease v$CURRENT_POETRY_VER does not exist in github, using this version"
 
           else

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -66,8 +66,24 @@ jobs:
       - name: "Determine New Version"
         id: "versioning"
         run: |
-          # Perform the bump based on the user input
-          poetry version ${{ github.event.inputs.bump_rule }}
+          # Bump the poetry version based on the user input
+          CURRENT_POETRY_VER=$(poetry version --short)
+          GITHUB_RELEASE_EXISTS=$(gh release view v$CURRENT_POETRY_VER --json publishedAt --jq '.publishedAt')
+
+          # Unconditionally bump the version if the current version is alpha0 or beta0
+          if [[ $CURRENT_POETRY_VER == *a0 || $CURRENT_POETRY_VER == *b0 ]]; then
+            echo "Bumping poetry version"
+            poetry version ${{ github.event.inputs.bump_rule }}
+
+          # If the bump rule is prerelease and a release doesn't already exist in github we don't bump the version
+          # This is because we've already bumped to the prerelease version after the previous release
+          elif [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" && -z "$GITHUB_RELEASE_EXISTS" ]]; then
+            echo "Prerelease v$CURRENT_POETRY_VER does not exist in github, using this version"
+
+          else
+            echo "Bumping poetry version"
+            poetry version ${{ github.event.inputs.bump_rule }}
+          fi
 
           # Capture the New version string for use in other steps
           NEW_VER=$(poetry version --short)

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -80,7 +80,7 @@ jobs:
 
           # If the bump rule is prerelease and a release doesn't already exist in github we don't bump the version
           # This is because we've already bumped to the prerelease version after the previous release
-          elif [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" && "$CURRENT_POETRY_VER" =~ \\(a|b|rc\\)\\d+$ && -z "$GITHUB_RELEASE_EXISTS" ]]; then
+          elif [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" && "$CURRENT_POETRY_VER" =~ (a|b|rc)\d+$ && -z "$GITHUB_RELEASE_EXISTS" ]]; then
             echo "Prerelease v$CURRENT_POETRY_VER does not exist in github, using this version"
 
           else

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -75,12 +75,12 @@ jobs:
           set -e
 
           # Unconditionally bump the version if the current version is alpha0 or beta0
-          if [[ $CURRENT_POETRY_VER == *a0 || $CURRENT_POETRY_VER == *b0 ]]; then
+          if [[ $CURRENT_POETRY_VER == *a0 || $CURRENT_POETRY_VER == *b0 || $CURRENT_POETRY_VER == *rc0 ]]; then
             poetry version ${{ github.event.inputs.bump_rule }}
 
           # If the bump rule is prerelease and a release doesn't already exist in github we don't bump the version
           # This is because we've already bumped to the prerelease version after the previous release
-          elif [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" && -z "$GITHUB_RELEASE_EXISTS" ]]; then
+          elif [[ "${{ github.event.inputs.bump_rule }}" == "prerelease" && "$CURRENT_POETRY_VER" =~ \(a|b|rc\)\d+$ && -z "$GITHUB_RELEASE_EXISTS" ]]; then
             echo "Prerelease v$CURRENT_POETRY_VER does not exist in github, using this version"
 
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
 
           git checkout -b "$BRANCH_NAME"
 
-          poetry version prepatch
+          poetry version prerelease
           git add pyproject.toml && git commit -m "Bump version"
           git push origin "$BRANCH_NAME"
 

--- a/changes/160.housekeeping
+++ b/changes/160.housekeeping
@@ -1,0 +1,1 @@
+Fixed the prepare release workflow bumping the version on prereleases resulting in a version number that is 2 ahead of the last release.

--- a/docs/dev/release_checklist.md
+++ b/docs/dev/release_checklist.md
@@ -184,7 +184,7 @@ Publish the release!
 
 First, sync your `main` branch with upstream changes: `git switch main && git pull`.
 
-Create a new branch from `main` called `release-1.4.2-to-develop` and use `poetry version prepatch` to bump the development version to the next release.
+Create a new branch from `main` called `release-1.4.2-to-develop` and use `poetry version prerelease` to bump the development version to the next release.
 
 For example, if you just released `v1.4.2`:
 
@@ -192,7 +192,7 @@ For example, if you just released `v1.4.2`:
 > git switch -c release-1.4.2-to-develop main
 Switched to a new branch 'release-1.4.2-to-develop'
 
-> poetry version prepatch
+> poetry version prerelease
 Bumping version from 1.4.2 to 1.4.3a1
 
 > git add pyproject.toml && git commit -m "Bump version"


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot Dev Example App! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: NAPPS-1159

## What's Changed

- If the existing version number is alpha0 or beta0, bump unconditionally
- If the user requests a prerelease bump but the existing version in pyproject.toml does not match a release in github, don't bump the version because it was already bumped after the previous release
- Otherwise, bump the version

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
