### PR TITLE
Add a previous_version prompt to prepare-release workflow

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -21,6 +21,10 @@ on: # yamllint disable-line rule:truthy rule:comments
         description: "Date of the release YYYY-MM-DD (defaults to today's date in the US Eastern TZ)."
         required: false
         default: ""
+      previous_version:
+        description: "The previous version tag to use for generating release notes (defaults to the latest tag or initial commit if no tags exist)."
+        required: false
+        default: ""
 
 jobs:
   prepare-release:
@@ -53,7 +57,11 @@ jobs:
 
           # 2. Try to get the previous version tag
           # If it fails (no tags), get the hash of the first commit
-          if PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null); then
+          if [ -n "${{ github.event.inputs.previous_version }}" ]; then
+            PREV_TAG="${{ github.event.inputs.previous_version }}"
+            echo "Using user-specified previous version: $PREV_TAG"
+            echo "PREVIOUS_TAG=$PREV_TAG" >> $GITHUB_ENV
+          elif PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null); then
             echo "PREVIOUS_TAG=$PREV_TAG" >> $GITHUB_ENV
             echo "Found previous tag: $PREV_TAG"
           else

--- a/changes/161.housekeeping
+++ b/changes/161.housekeeping
@@ -1,0 +1,1 @@
+Added previous_version prompt to prepare-release workflow.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot Dev Example App! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# NAPPS-1059

## What's Changed

When working on the `next` branch and creating releases in `next` and merging changes from `develop`, we can add tags from the patch/minor that could appear as more recent in our `next` branch. This PR allows the user to specify the previous version to use, in case this issue would occur.

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
