### PR TITLE
Sync release notes from ltm to develop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,3 +171,62 @@ jobs:
             --body "Please do a merge commit." \
             --base "${{ steps.branch.outputs.target_branch }}" \
             --head "${{ steps.branch.outputs.branch_name }}"
+
+  sync-ltm-release-notes-to-develop:
+    if: "startsWith(github.event.release.target_commitish, 'ltm-')"
+    permissions:
+      contents: "write"
+      pull-requests: "write"
+    name: "Sync release notes from ${{ github.event.release.target_commitish }} to develop"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout develop"
+        uses: "actions/checkout@v4"
+        with:
+          ref: "develop"
+          fetch-depth: 0
+
+      - name: "Create branch and sync release notes from ltm"
+        id: "branch"
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+          SOURCE_BRANCH="${{ github.event.release.target_commitish }}"
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          VERSION="${TAG_NAME#v}"
+          BRANCH_NAME="release-${VERSION}-notes-to-develop"
+
+          # Fetch the ltm source branch so we can checkout files from it
+          git fetch origin "$SOURCE_BRANCH"
+
+          # Ensure release branch doesn't already exist
+          if git rev-parse --verify "origin/$BRANCH_NAME" > /dev/null 2>&1; then
+            echo "Error: Release branch $BRANCH_NAME already exists."
+            exit 1
+          fi
+
+          git switch -c "$BRANCH_NAME"
+          git checkout "origin/$SOURCE_BRANCH" -- docs/admin/release_notes/
+
+          # Check if there are any changes in /release_notes
+          if git diff --staged --quiet; then
+            echo "No release notes changes to sync from $SOURCE_BRANCH to develop."
+            exit 0
+          fi
+
+          git commit -m "Sync release notes from $SOURCE_BRANCH"
+          git push origin "$BRANCH_NAME"
+
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: "Create Pull Request"
+        if: "steps.branch.outputs.branch_name != ''"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          gh pr create \
+            --title "Sync release notes from ${{ github.event.release.target_commitish }} (${{ github.event.release.tag_name }}) to develop" \
+            --body "Please do a merge commit." \
+            --base "develop" \
+            --head "${{ steps.branch.outputs.branch_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,8 +194,7 @@ jobs:
 
           SOURCE_BRANCH="${{ github.event.release.target_commitish }}"
           TAG_NAME="${{ github.event.release.tag_name }}"
-          VERSION="${TAG_NAME#v}"
-          BRANCH_NAME="release-${VERSION}-notes-to-develop"
+          BRANCH_NAME="release-${TAG_NAME#v}-notes-to-develop"
 
           # Fetch the ltm source branch so we can checkout files from it
           git fetch origin "$SOURCE_BRANCH"

--- a/changes/164.housekeeping
+++ b/changes/164.housekeeping
@@ -1,0 +1,1 @@
+Added a release workflow job to sync release notes from `ltm` branches back to `develop` via an automated pull request.


### PR DESCRIPTION
NAPPS-942

## What's Changed
Added a release workflow job to sync release notes from `ltm` branches back to `develop` via an automated pull request.

# Screenshots
## Workflow run successfully
<img width="866" height="589" alt="Screenshot 2026-05-13 at 6 15 17 PM" src="https://github.com/user-attachments/assets/4b25fbfa-e3e7-47f7-8e90-2a24a025ac00" />

## PR created from ltm-2.4 to develop only syncing release notes
<img width="2521" height="1135" alt="Screenshot 2026-05-13 at 6 15 31 PM" src="https://github.com/user-attachments/assets/00415c24-0190-436d-9903-897dbccbfe7a" />


## To Do
<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
