### PR TITLE
NAPPS-1249 open PR from main to next after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,3 +229,62 @@ jobs:
             --body "Please do a merge commit." \
             --base "develop" \
             --head "${{ steps.branch.outputs.branch_name }}"
+
+  create-pr-to-next:
+    if: "github.event.release.target_commitish == 'develop'"
+    permissions:
+      contents: "write"
+      pull-requests: "write"
+    name: "Create a PR from develop into next"
+    needs:
+      - "publish-github"
+      - "publish-pypi"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout develop"
+        uses: "actions/checkout@v4"
+        with:
+          ref: "develop"
+          fetch-depth: 0
+
+      - name: "Create release branch from develop"
+        id: "branch"
+        run: |
+
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+          # Skip if there is no 'next' branch to merge into.
+          if ! git ls-remote --exit-code --heads origin next > /dev/null 2>&1; then
+            echo "No 'next' branch exists; skipping develop -> next PR."
+            exit 0
+          fi
+
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          VERSION="${TAG_NAME#v}"
+
+          BRANCH_NAME="release-${VERSION}-to-next"
+
+          # Ensure release branch doesn't already exist
+          if git rev-parse --verify origin/$BRANCH_NAME > /dev/null 2>&1; then
+            echo "Error: Release branch $BRANCH_NAME already exists."
+            exit 1
+          fi
+
+          # Snapshot develop at release time so later develop commits don't alter the PR.
+          # No version bump: next maintains its own (higher) version line.
+          git checkout -b "$BRANCH_NAME"
+          git push origin "$BRANCH_NAME"
+
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: "Create a PR to next"
+        if: "steps.branch.outputs.branch_name != ''"
+        env:
+          GH_TOKEN: "${{ secrets.GH_NAUTOBOT_BOT_TOKEN }}"
+        run: |
+          gh pr create \
+            --title "Post release ${{ github.event.release.tag_name }} to next" \
+            --body "Please do a merge commit." \
+            --base "next" \
+            --head "${{ steps.branch.outputs.branch_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,6 @@ jobs:
           fi
 
           # Snapshot develop at release time so later develop commits don't alter the PR.
-          # No version bump: next maintains its own (higher) version line.
           git checkout -b "$BRANCH_NAME"
           git push origin "$BRANCH_NAME"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,32 +231,28 @@ jobs:
             --head "${{ steps.branch.outputs.branch_name }}"
 
   create-pr-to-next:
-    if: "github.event.release.target_commitish == 'develop'"
+    if: "github.event.release.target_commitish == 'main'"
     permissions:
       contents: "write"
       pull-requests: "write"
-    name: "Create a PR from develop into next"
+    name: "Create a PR from main into next"
     needs:
       - "publish-github"
       - "publish-pypi"
     runs-on: "ubuntu-latest"
     steps:
-      - name: "Checkout develop"
+      - name: "Checkout main"
         uses: "actions/checkout@v4"
         with:
-          ref: "develop"
+          ref: "main"
           fetch-depth: 0
 
-      - name: "Create release branch from develop"
+      - name: "Create release branch from main"
         id: "branch"
         run: |
-
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-
           # Skip if there is no 'next' branch to merge into.
           if ! git ls-remote --exit-code --heads origin next > /dev/null 2>&1; then
-            echo "No 'next' branch exists; skipping develop -> next PR."
+            echo "No 'next' branch exists; skipping main -> next PR."
             exit 0
           fi
 
@@ -271,7 +267,7 @@ jobs:
             exit 1
           fi
 
-          # Snapshot develop at release time so later develop commits don't alter the PR.
+          # Base off main, since it's in the released state.
           git checkout -b "$BRANCH_NAME"
           git push origin "$BRANCH_NAME"
 

--- a/changes/172.housekeeping
+++ b/changes/172.housekeeping
@@ -1,1 +1,1 @@
-Added a release workflow job that opens a pull request from `develop` into `next` after a release is published from `develop`.
+Added a release workflow job that opens a pull request from `main` into `next` after a release is published from `main`.

--- a/changes/172.housekeeping
+++ b/changes/172.housekeeping
@@ -1,0 +1,1 @@
+Added a release workflow job that opens a pull request from `develop` into `next` after a release is published from `develop`.

--- a/docs/dev/release_checklist.md
+++ b/docs/dev/release_checklist.md
@@ -72,10 +72,7 @@ After a release has been published from the `main` branch, a new PR will automat
 
 ### Sync the Release to `next`
 
-If a `next` branch exists (used to stage the next major or minor version), publishing a release from the `develop` branch will also automatically create a PR to forward-port the released changes from `develop` into `next`, so the `next` branch stays current. Review and merge this PR once CI has completed and the PR has been approved.
-
-!!! important
-    Resolve the `pyproject.toml` version conflict in favor of `next`, which maintains its own version line. As with all release PRs, do not squash merge -- select `Create a merge commit` when merging in GitHub.
+Publishing a release from the `develop` branch will also automatically create a PR to forward-port the released changes from `develop` into `next`, so the `next` branch stays up to date.
 
 If no `next` branch exists, this step is skipped automatically.
 

--- a/docs/dev/release_checklist.md
+++ b/docs/dev/release_checklist.md
@@ -70,6 +70,15 @@ A draft release will automatically be created in GitHub when the Prepare Release
 
 After a release has been published from the `main` branch, a new PR will automatically be created to merge the changes from `main` back into `develop` with a version bump to the next development version (e.g. `1.4.3a1`). Review and merge this PR once CI has completed and the PR has been approved.
 
+### Sync the Release to `next`
+
+If a `next` branch exists (used to stage the next major or minor version), publishing a release from the `develop` branch will also automatically create a PR to forward-port the released changes from `develop` into `next`, so the `next` branch stays current. Review and merge this PR once CI has completed and the PR has been approved.
+
+!!! important
+    Resolve the `pyproject.toml` version conflict in favor of `next`, which maintains its own version line. As with all release PRs, do not squash merge -- select `Create a merge commit` when merging in GitHub.
+
+If no `next` branch exists, this step is skipped automatically.
+
 ## Legacy Documentation for Releases
 
 Please use the above process for all releases going forward, but if you need to refer to the old manual release process for any reason, here are the steps that were previously followed for releases.

--- a/docs/dev/release_checklist.md
+++ b/docs/dev/release_checklist.md
@@ -72,7 +72,7 @@ After a release has been published from the `main` branch, a new PR will automat
 
 ### Sync the Release to `next`
 
-Publishing a release from the `develop` branch will also automatically create a PR to forward-port the released changes from `develop` into `next`, so the `next` branch stays up to date.
+Publishing a release from the `main` branch will also automatically create a PR to forward-port the released changes from `main` into `next`, so the `next` branch stays up to date.
 
 If no `next` branch exists, this step is skipped automatically.
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot Dev Example App! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: NAPPS-1249

## What's Changed

Adds automation so that publishing a release from `main` automatically opens a PR forward-porting `main` into `next`.

Based on previous post-release `main` -> `develop` sync, but for the `main` -> `next` direction.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
