### PR TITLE
Make Python and Poetry versions env vars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on: # yamllint disable-line rule:truthy rule:comments
   release:
     types: ["published"]
 
+env:
+  POETRY_VERSION: "2.1.3"
+  PYTHON_VERSION: "3.12"
+
 jobs:
   build:
     name: "Build package with poetry"
@@ -14,8 +18,8 @@ jobs:
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
-          poetry-version: "2.1.3"
-          python-version: "3.12"
+          poetry-version: "${{ env.POETRY_VERSION }}"
+          python-version: "${{ env.PYTHON_VERSION }}"
           poetry-install-options: "--no-root"
       - name: "Build Documentation"
         run: "poetry run invoke build-and-check-docs"
@@ -125,7 +129,7 @@ jobs:
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
-          poetry-version: "2.1.3"
+          poetry-version: "${{ env.POETRY_VERSION }}"
           poetry-install-options: "--no-root"
 
       - name: "Create release branch and bump version"

--- a/changes/175.housekeeping
+++ b/changes/175.housekeeping
@@ -1,0 +1,1 @@
+Changed the release workflow to define the Python and Poetry versions as workflow-level environment variables.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot Dev Example App! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

## What's Changed

Instead of straight values we could make `python-version` and `poetry-version` env variables.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
