### PR TITLE
Fix djlint CI failure on apps with no Django templates

### DIFF
--- a/changes/176.housekeeping
+++ b/changes/176.housekeeping
@@ -1,0 +1,1 @@
+Fixed djlint CI failure for apps with no Django templates, caused by djlint 1.39.5 returning a non-zero exit code when no files match the lint run.

--- a/tasks.py
+++ b/tasks.py
@@ -877,10 +877,11 @@ def djlint(context, target=None):
     if not target:
         # As of djlint 1.39.5, djlint returns a non-zero exit code when no files match the lint
         # run (https://github.com/djlint/djLint/issues/1112).
-        if not any(Path("nautobot_dev_example/templates").rglob("*.html")):
+        templates_dir = Path(__file__).parent / "nautobot_dev_example" / "templates"
+        if not any(templates_dir.rglob("*.html")):
             print("djlint: no Django templates found to lint; skipping.")
             return
-        target = ["."]
+        target = ["nautobot_dev_example/templates/"]
 
     command = "djlint --lint "
     command += " ".join(target)

--- a/tasks.py
+++ b/tasks.py
@@ -875,6 +875,11 @@ def ruff(context, action=None, target=None, fix=False, output_format="concise"):
 def djlint(context, target=None):
     """Run djlint to lint Django templates."""
     if not target:
+        # As of djlint 1.39.5, djlint returns a non-zero exit code when no files match the lint
+        # run (https://github.com/djlint/djLint/issues/1112).
+        if not any(Path("nautobot_dev_example/templates").rglob("*.html")):
+            print("djlint: no Django templates found to lint; skipping.")
+            return
         target = ["."]
 
     command = "djlint --lint "

--- a/tasks.py
+++ b/tasks.py
@@ -888,7 +888,6 @@ def djlint(context, target=None):
     if result.ok:
         return
     if "No files to check" in result.stdout:
-        print("djlint: no files to lint; skipping.")
         return
     print(result.stderr, end="")
     raise Exit(code=result.return_code or 1)

--- a/tasks.py
+++ b/tasks.py
@@ -875,20 +875,23 @@ def ruff(context, action=None, target=None, fix=False, output_format="concise"):
 def djlint(context, target=None):
     """Run djlint to lint Django templates."""
     if not target:
-        # As of djlint 1.39.5, djlint returns a non-zero exit code when no files match the lint
-        # run (https://github.com/djlint/djLint/issues/1112).
-        templates_dir = Path(__file__).parent / "nautobot_dev_example" / "templates"
-        if not any(templates_dir.rglob("*.html")):
-            print("djlint: no Django templates found to lint; skipping.")
-            return
-        target = ["nautobot_dev_example/templates/"]
+        target = ["."]
 
     command = "djlint --lint "
     command += " ".join(target)
 
-    exit_code = 0 if run_command(context, command, warn=True) else 1
-    if exit_code != 0:
-        raise Exit(code=exit_code)
+    # As of djlint 1.39.5, djlint returns a non-zero exit code when no files match the lint run
+    # (https://github.com/djlint/djLint/issues/1112)
+    result = run_command(context, command, warn=True, hide="both", pty=False)
+    print(result.stdout, end="")
+
+    if result.ok:
+        return
+    if "No files to check" in result.stdout:
+        print("djlint: no files to lint; skipping.")
+        return
+    print(result.stderr, end="")
+    raise Exit(code=result.return_code or 1)
 
 
 @task(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot Dev Example App! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

## What's Changed

Added a check to skip running djlint when there are no *.html files in app's templates directory. This handles the non-zero exit code returned when there are no files to check, introduced in djlint's 1.39.5 version. 

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
