### PR TITLE
Add opt-in ephemeral Docker host ports to the development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -308,7 +308,7 @@ invoke.yml
 public
 /compose.yaml
 /dump.sql
-/.service_ports.json
+.service_ports.json
 /nautobot_dev_example/static/nautobot_dev_example/docs
 # Avoid accidental commit of analytics template override generated via ./docs/insert-analytics.sh
 docs/assets/overrides/main.html

--- a/.gitignore
+++ b/.gitignore
@@ -308,6 +308,7 @@ invoke.yml
 public
 /compose.yaml
 /dump.sql
+/.service_ports.json
 /nautobot_dev_example/static/nautobot_dev_example/docs
 # Avoid accidental commit of analytics template override generated via ./docs/insert-analytics.sh
 docs/assets/overrides/main.html

--- a/changes/180.added
+++ b/changes/180.added
@@ -1,0 +1,1 @@
+Added opt-in ephemeral Docker host ports for the development environment via the `ephemeral_ports` invoke setting.

--- a/changes/180.changed
+++ b/changes/180.changed
@@ -1,0 +1,1 @@
+Aligned the `docs` container to serve and publish on port 8001, matching `mkdocs.yml` and Nautobot core.

--- a/development/docker-compose.dev.yml
+++ b/development/docker-compose.dev.yml
@@ -21,9 +21,9 @@ services:
     # Note: explicitly enabling --livereload was added as a workaround
     # and can be removed if/when mkdocs is updated.
     # Ref: https://github.com/mkdocs/mkdocs/issues/4032
-    entrypoint: "mkdocs serve -v --livereload -a 0.0.0.0:8080"
+    entrypoint: "mkdocs serve -v --livereload -a 0.0.0.0:8001"
     ports:
-      - "8001:8080"
+      - "8001:8001"
     volumes:
       - "../:/source"
     image: "nautobot-dev-example/nautobot:${NAUTOBOT_VER}-py${PYTHON_VER}"

--- a/development/docker-compose.ephemeral-ports.yml
+++ b/development/docker-compose.ephemeral-ports.yml
@@ -1,0 +1,19 @@
+# Set host ports to ephemeral values to avoid conflicts with other local services.
+---
+services:
+  nautobot:
+    ports: !override
+      - "8080"
+  docs:
+    ports: !override
+      - "8001"
+# To expose postgres (5432), mysql (3306) on db service or redis (6379) to the host using
+# ephemeral ports, uncomment the following. Ensure to match the 2 indented spaces which
+# have the service nested under services.
+# db:
+#   ports: !override
+#     - "5432"
+#     - "3306"
+# redis:
+#   ports: !override
+#     - "6379"

--- a/docs/dev/dev_environment.md
+++ b/docs/dev/dev_environment.md
@@ -19,6 +19,7 @@ The [Invoke](http://www.pyinvoke.org/) library is used to provide some helper co
 - `local`: a boolean flag indicating if invoke tasks should be run on the host or inside the docker containers (default: False, commands will be run in docker containers)
 - `compose_dir`: the full path to a directory containing the project compose files
 - `compose_files`: a list of compose files applied in order (see [Multiple Compose files](https://docs.docker.com/compose/extends/#multiple-compose-files) for more information)
+- `ephemeral_ports`: Setting this value to `true` and not using any custom compose files will make all Nautobot containers with published ports expose themselves with dynamic ports. This is useful when running multiple Nautobot versions at the same time on the same machine so you won't experience system port conflicts. If setting `compose_files`, this will have no effect so please ensure to manually add the applicable `docker-compose.ephemeral-ports.yml` file or files to your list.
 
 Using **Invoke** these configuration options can be overridden using [several methods](https://docs.pyinvoke.org/en/stable/concepts/configuration.html). Perhaps the simplest is setting an environment variable `INVOKE_NAUTOBOT_DEV_EXAMPLE_VARIABLE_NAME` where `VARIABLE_NAME` is the variable you are trying to override. The only exception is `compose_files`, because it is a list it must be overridden in a YAML file. There is an example `invoke.yml` (`invoke.example.yml`) in this directory which can be used as a starting point.
 
@@ -44,6 +45,8 @@ invoke start
 ```
 
 The Nautobot server can now be accessed at [http://localhost:8080](http://localhost:8080) and the live documentation at [http://localhost:8001](http://localhost:8001).
+
+Every `invoke start` and `invoke debug` writes the published host port mappings to `.service_ports.json`, listing only the services that publish a port to the host. When ephemeral ports are enabled, Docker assigns dynamic host ports and this file captures the resulting values; with fixed ports it captures the static values instead. You can also inspect them with `invoke ps` or `docker compose port`, for example `docker compose port nautobot 8080`. To enable ephemeral ports with an environment variable, set `INVOKE_NAUTOBOT_DEV_EXAMPLE_EPHEMERAL_PORTS=1`; to disable them, unset the environment variable, set it to an empty value, or set it to `0`.
 
 To either stop or destroy the development environment use the following options.
 

--- a/invoke.example.yml
+++ b/invoke.example.yml
@@ -3,6 +3,7 @@ nautobot_dev_example:
   nautobot_ver: "3.0.0"
   python_ver: "3.12"
   # local: false
+  # ephemeral_ports: false
   # compose_dir: "/full/path/to/nautobot-app-dev-example/development"
 
 # The following is an example of using MySQL as the database backend

--- a/invoke.mysql.yml
+++ b/invoke.mysql.yml
@@ -10,3 +10,7 @@ nautobot_dev_example:
     - "docker-compose.redis.yml"
     - "docker-compose.mysql.yml"
     - "docker-compose.dev.yml"
+    # Uncomment the ephemeral-ports override below to use dynamic host ports with this
+    # custom compose file list. The `ephemeral_ports` invoke option only auto-applies when
+    # compose_files is left at its default, so it has no effect here and is intentionally omitted.
+    # - "docker-compose.ephemeral-ports.yml"

--- a/tasks.py
+++ b/tasks.py
@@ -197,7 +197,7 @@ def dump_service_ports_to_disk(context):
         if set(["nautobot"]).issubset(service_ports.keys()):
             break
 
-        sleep(5)
+        sleep(15)
 
     with open(".service_ports.json", "w", encoding="utf-8") as file:
         json.dump(service_ports, file, indent=4)

--- a/tasks.py
+++ b/tasks.py
@@ -12,6 +12,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import concurrent.futures
+import json
 import os
 import re
 import shutil
@@ -22,6 +24,13 @@ from time import sleep
 from invoke.collection import Collection
 from invoke.exceptions import Exit, UnexpectedExit
 from invoke.tasks import task as invoke_task
+
+ORIGINAL_COMPOSE_FILES = [
+    "docker-compose.base.yml",
+    "docker-compose.redis.yml",
+    "docker-compose.postgres.yml",
+    "docker-compose.dev.yml",
+]
 
 
 def is_truthy(arg):
@@ -56,13 +65,9 @@ namespace.configure(
             "project_name": "nautobot-dev-example",
             "python_ver": "3.12",
             "local": False,
+            "ephemeral_ports": False,
             "compose_dir": os.path.join(os.path.dirname(__file__), "development"),
-            "compose_files": [
-                "docker-compose.base.yml",
-                "docker-compose.redis.yml",
-                "docker-compose.postgres.yml",
-                "docker-compose.dev.yml",
-            ],
+            "compose_files": ORIGINAL_COMPOSE_FILES.copy(),
             "compose_http_timeout": "86400",
         }
     }
@@ -138,6 +143,13 @@ def docker_compose(context, command, **kwargs):
         compose_file_path = os.path.join(context.nautobot_dev_example.compose_dir, compose_file)
         compose_command_tokens.append(f' -f "{compose_file_path}"')
 
+    if (
+        context.nautobot_dev_example.ephemeral_ports
+        and context.nautobot_dev_example.compose_files == ORIGINAL_COMPOSE_FILES
+    ):
+        compose_file_path = os.path.join(context.nautobot_dev_example.compose_dir, "docker-compose.ephemeral-ports.yml")
+        compose_command_tokens.append(f' -f "{compose_file_path}"')
+
     compose_command_tokens.append(command)
 
     # If `service` was passed as a kwarg, add it to the end.
@@ -145,10 +157,50 @@ def docker_compose(context, command, **kwargs):
     if service is not None:
         compose_command_tokens.append(service)
 
-    print(f'Running docker compose command "{command}"')
+    if "hide" not in kwargs:
+        print(f'Running docker compose command "{command}"')
     compose_command = " ".join(compose_command_tokens)
 
     return context.run(compose_command, env=build_env, **kwargs)
+
+
+@task
+def dump_service_ports_to_disk(context):
+    """Useful for downstream utilities without direct docker access to determine ports.
+
+    This function will sometimes be called asynchronously while containers are still
+    firing up, hence the `attempt` loop.
+    """
+    service_ports = {}
+
+    for _ in range(4):
+        result = docker_compose(context, "ps --format json", hide=True)
+
+        for line in result.stdout.splitlines():
+            try:
+                service_def = json.loads(line)
+                service_name = re.search(
+                    r"com\.docker\.compose\.service=(?P<service>\w+)", service_def["Labels"]
+                ).group("service")
+
+                ports_found = {}
+                for port in service_def["Publishers"]:
+                    if port.get("PublishedPort", 0):
+                        ports_found[port["TargetPort"]] = port["PublishedPort"]
+
+                if ports_found:
+                    service_ports[service_name] = ports_found
+            except (json.decoder.JSONDecodeError, AttributeError, IndexError, KeyError):
+                continue
+
+        # Confirm nautobot has started
+        if set(["nautobot"]).issubset(service_ports.keys()):
+            break
+
+        sleep(5)
+
+    with open(".service_ports.json", "w", encoding="utf-8") as file:
+        json.dump(service_ports, file, indent=4)
 
 
 def run_command(context, command, service="nautobot", **kwargs):
@@ -294,7 +346,9 @@ def debug(context, service=None):
     """Start specified or all services and its dependencies in debug mode."""
     service = " ".join(service) if service else ""
     print(f"Starting {service or 'all services'} in debug mode...")
-    docker_compose(context, "up", service=service)
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        executor.submit(dump_service_ports_to_disk, context)
+        docker_compose(context, "up", service=service)
 
 
 @task(
@@ -308,6 +362,7 @@ def start(context, service=None):
     service = " ".join(service) if service else ""
     print(f"Starting {service or 'all services'} in detached mode...")
     docker_compose(context, "up --detach", service=service)
+    dump_service_ports_to_disk(context)
 
 
 @task(


### PR DESCRIPTION
Backport of cookiecutter-nautobot-app #399, validated here before that template change merges.

Setting `ephemeral_ports: true` in invoke.yml, or
`INVOKE_NAUTOBOT_DEV_EXAMPLE_EPHEMERAL_PORTS=1`, layers docker-compose.ephemeral-ports.yml onto the default compose file list so Docker assigns dynamic host ports for the nautobot and docs services. This allows multiple Nautobot dev environments to run concurrently without host port conflicts. The override is intentionally skipped when compose_files is customized, since the file list is then caller-owned.

invoke start and invoke debug now record the published host port mappings in .service_ports.json for downstream tooling that has no direct Docker access.

Also aligns the docs container to serve and publish on 8001, matching mkdocs.yml and Nautobot core. Previously mkdocs listened on 8080 while 8001 was published, which left docs unreachable once ephemeral ports were in play.

<!--
    Thank you for your interest in contributing to Nautobot Dev Example App! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes:

## What's Changed
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

### Ephemeral host ports

Setting `ephemeral_ports: true` in `invoke.yml`, or exporting
`INVOKE_NAUTOBOT_DEV_EXAMPLE_EPHEMERAL_PORTS=1`, layers a new
`development/docker-compose.ephemeral-ports.yml` onto the default compose file list.
Docker then assigns dynamic host ports for the `nautobot` and `docs` services, so
multiple Nautobot dev environments can run concurrently without host port conflicts.
The override is deliberately skipped when `compose_files` has been customized, since
the file list is caller-owned at that point. `invoke.mysql.yml` carries a comment
explaining how to opt in manually. The `db` and `redis` stanzas are present but
commented out in the override file for anyone who needs them exposed.

### Port discovery via `.service_ports.json`
`invoke start` and `invoke debug` now record the published host port mappings to
`.service_ports.json` (gitignored) for downstream tooling with no direct Docker
access. `debug` writes it from a worker thread since `up` blocks. The file is written
in both modes, capturing dynamic ports when ephemeral is on and static ones when off.

### Docs container port alignment
`development/docker-compose.dev.yml` now has the docs container serve and publish on
8001 (`-a 0.0.0.0:8001`, `8001:8001`) instead of serving on 8080 and publishing
`8001:8080`. This matches `mkdocs.yml` and Nautobot core. It is required here because
the ephemeral override publishes a dynamic host port to container port 8001, which was
previously not the port mkdocs listened on. See validation section 3.

## Validation
Tested against a live dev environment on macOS with Docker, Nautobot 3.0.0 / Python 3.12.

### 1. Motivation: fixed ports conflict with a second environment
With another Nautobot dev environment already holding host port 8080, the default
fixed-port configuration cannot start:

    Error response from daemon: failed to set up container networking: driver failed
    programming external connectivity on endpoint nautobot-dev-example-nautobot-1:
    Bind for 0.0.0.0:8080 failed: port is already allocated

### 2. Ephemeral ports resolve the conflict
With `ephemeral_ports: true`, the same stack starts cleanly alongside the environment
still holding 8080:

    nautobot-dev-example-docs-1       0.0.0.0:56319->8001/tcp
    nautobot-dev-example-nautobot-1   0.0.0.0:56324->8080/tcp

`.service_ports.json` matches `docker ps` exactly:

    {
        "docs":     { "8001": 56319 },
        "nautobot": { "8080": 56324 }
    }

Both services are reachable on their dynamic ports:

    http://localhost:56324/health/ -> HTTP 200
    http://localhost:56319/        -> HTTP 302 -> /projects/dev-example/en/latest/ -> HTTP 200

### 3. Why the docs port change is included
Reverting only the `docker-compose.dev.yml` docs change (back to `-a 0.0.0.0:8080`
with `8001:8080`) and restarting makes the docs container unreachable under ephemeral
ports. The override publishes a dynamic host port to container port 8001, but mkdocs
is listening on 8080:

    nautobot-dev-example-docs-1   0.0.0.0:56453->8001/tcp
    curl http://localhost:56453/  -> exit 56 (connection reset), HTTP 000

Restoring the fix returns it to HTTP 200.

### 4. No regression with ephemeral ports disabled
With ports 8080 and 8001 free and `INVOKE_NAUTOBOT_DEV_EXAMPLE_EPHEMERAL_PORTS=0`,
behavior is unchanged from before this PR:

    nautobot-dev-example-nautobot-1   0.0.0.0:8080->8080/tcp
    nautobot-dev-example-docs-1       0.0.0.0:8001->8001/tcp
    { "docs": { "8001": 8001 }, "nautobot": { "8080": 8080 } }
    http://localhost:8080/health/ -> HTTP 200
    http://localhost:8001/        -> HTTP 200

This also confirms the documented env-var toggle: Invoke casts a bool-typed config
value from the environment as "anything other than an empty string or `0`", so `=0`
genuinely disables the feature.

## Known limitations

`dump_service_ports_to_disk` retries four times with 15-second sleeps waiting for the `nautobot` service to publish its ports; under `invoke debug` it runs on a thread against a still-starting stack, so on a very slow machine it could write an incomplete file. This is how it works in the nautobot repo, so I opted for consistency. Improving this in cookiecutter and core (e.g. polling on a shorter interval against an overall timeout and skipping the wait entirely when the `nautobot` container is not among the services being started) would be nice, but felt outside the scope of this PR.


## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design